### PR TITLE
Fix IRTools UUID to match registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "IRTools"
-uuid = "71c1cb0c-a83f-11e8-19ce-a5dd18e12d22"
+uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
 version = "0.1.0"
 


### PR DESCRIPTION
Otherwise the package manager gets confused and installs to versions of the package.