### PR TITLE
Relooper Algorithm

### DIFF
--- a/src/IRTools.jl
+++ b/src/IRTools.jl
@@ -1,7 +1,7 @@
 module IRTools
 
 using MacroTools
-using MacroTools: prewalk, postwalk
+using MacroTools: @q, prewalk, postwalk
 
 export @code_ir
 

--- a/src/IRTools.jl
+++ b/src/IRTools.jl
@@ -17,6 +17,7 @@ include("reflection/utils.jl")
 include("reflection/dynamo.jl")
 
 include("passes/passes.jl")
+include("passes/relooper.jl")
 
 include("interpret.jl")
 include("eval.jl")

--- a/src/ir/ir.jl
+++ b/src/ir/ir.jl
@@ -31,6 +31,7 @@ Branch(br::Branch; condition = br.condition,
   Branch(condition, block, args)
 
 isreturn(b::Branch) = b.block == 0 && length(b.args) == 1
+returnvalue(b::Branch) = b.args[1]
 isconditional(b::Branch) = b.condition != nothing
 
 Base.:(==)(a::Branch, b::Branch) =
@@ -146,10 +147,10 @@ function explicitbranch!(b::Block)
   if all(isconditional, branches(a))
     branch!(a, b.id)
   end
-  return
+  return b
 end
 
-explicitbranch!(ir::IR) = foreach(explicitbranch!, blocks(ir))
+explicitbranch!(ir::IR) = (foreach(explicitbranch!, blocks(ir)); return ir)
 
 function branches(b::Block, c::Block)
   c.id == b.id+1 && explicitbranch!(c)
@@ -176,7 +177,7 @@ Retreive the return value of a block.
 """
 function returnvalue(b::Block)
   isreturn(branches(b)[end]) || error("Block does not return")
-  return branches(b)[end].args[1]
+  return returnvalue(branches(b)[end])
 end
 
 """

--- a/src/passes/relooper.jl
+++ b/src/passes/relooper.jl
@@ -52,7 +52,8 @@ function reaches_unique(rs)
   Dict(b => filter(c -> !any(rs -> c in rs, others(b)), cs) for (b, cs) in rs)
 end
 
-function reloop_loop(cfg::CFG, blocks, entry, done, rs)
+function reloop_loop(cfg::CFG, blocks, entry, done)
+  rs = Dict(b => reaching(cfg, b, ignore = done) for b in blocks)
   body = filter(b -> any(e -> e in rs[b], entry), blocks)
   next = setdiff(blocks, body)
   Loop(reloop(cfg, blocks = body, entry = entry, done = union(done, entry)),
@@ -60,15 +61,15 @@ function reloop_loop(cfg::CFG, blocks, entry, done, rs)
  end
 
 function reloop(cfg::CFG; blocks = 1:length(cfg.graph), entry = [1], done = Int[])
-  isempty(blocks) && return
-  rs = Dict(b => reaching(cfg, b, ignore = done) for b in blocks)
+  (isempty(blocks) || isempty(entry)) && return
+  rs = Dict(b => reaching(cfg, b, ignore = done) for b in entry)
   if length(entry) == 1 && entry[] ∉ rs[entry[]]
     next = setdiff(blocks, entry[])
     Simple(entry[],
            reloop(cfg, blocks = next,
                   entry = intersect(cfg.graph[entry[]], blocks), done = done))
   elseif all(b -> isempty(setdiff(entry, rs[b])), entry)
-    reloop_loop(cfg, blocks, entry, done, rs)
+    reloop_loop(cfg, blocks, entry, done)
   elseif (rsu = reaches_unique(rs); !all(isempty, values(rsu)))
     unique = filter(b -> !isempty(rsu[b]), entry)
     inner = [reloop(cfg, blocks = union(b, rsu[b]), entry = [b], done = done) for b in unique]
@@ -76,19 +77,32 @@ function reloop(cfg::CFG; blocks = 1:length(cfg.graph), entry = [1], done = Int[
     es = intersect(next, union(entry, reaching.((cfg,), unique)...))
     Multiple(inner, reloop(cfg, blocks = next, entry = es, done = done))
   else
-    reloop_loop(cfg, blocks, entry, done, rs)
+    reloop_loop(cfg, blocks, entry, done)
   end
 end
 
+const indent = "    "
+
 printstructure(io::IO, ::Nothing, level) = nothing
 
+_printstructure(io::IO, s, level) = printstructure(io, s, level)
+
+function _printstructure(io::IO, s::Simple, level)
+  println(io, indent^level, s.block)
+  _printstructure(io, s.next, level)
+end
+
 function printstructure(io::IO, s::Simple, level)
-  println(io, "  "^level, s.block)
-  printstructure(io, s.next, level)
+  if s.next == nothing
+    _printstructure(io, s, level)
+  else
+    println(io, indent^level, "Simple:")
+    _printstructure(io, s, level+1)
+  end
 end
 
 function printstructure(io::IO, s::Multiple, level)
-  println(io, "  "^level, "Multiple:")
+  println(io, indent^level, "Multiple:")
   for b in s.inner
     printstructure(io, b, level+1)
   end
@@ -96,12 +110,12 @@ function printstructure(io::IO, s::Multiple, level)
 end
 
 function printstructure(io::IO, s::Loop, level)
-  println(io, "  "^level, "Loop:")
+  println(io, indent^level, "Loop:")
   printstructure(io, s.inner, level+1)
   printstructure(io, s.next, level)
 end
 
 function Base.show(io::IO, b::Union{Simple,Multiple,Loop})
   println(io, "Structured CFG:")
-  printstructure(io, b, 0)
+  _printstructure(io, b, 0)
 end

--- a/src/passes/relooper.jl
+++ b/src/passes/relooper.jl
@@ -1,0 +1,107 @@
+struct CFG
+  graph::Vector{Vector{Int}}
+end
+
+function CFG(ir::IR)
+  graph = Vector{Int}[]
+  for b in blocks(ir)
+    push!(graph, Int[])
+    for c in successors(b)
+      push!(graph[end], c.id)
+    end
+  end
+  return CFG(graph)
+end
+
+Base.:(==)(a::CFG, b::CFG) = a.graph == b.graph
+
+function reaching(c::CFG, i::Integer, rs = Int[]; ignore = Int[])
+  for j in c.graph[i]
+    j in rs && return rs
+    j in ignore && continue
+    push!(rs, j)
+    reaching(c, j, rs, ignore = ignore)
+  end
+  return rs
+end
+
+struct Simple
+  block::Int
+  next
+end
+
+Simple(n) = Simple(n, nothing)
+
+struct Loop
+  inner
+  next
+end
+
+struct Multiple
+  inner::Vector{Any}
+  next
+end
+
+for T in [Simple, Loop, Multiple]
+  @eval Base.:(==)(a::$T, b::$T) = $(reduce((a, b) -> :($a&&$b), [:(a.$f == b.$f) for f in fieldnames(T)]))
+end
+
+function reaches_unique(rs)
+  rs = Dict(b => union(b, cs) for (b, cs) in rs)
+  others(b) = union([cs for (c, cs) in rs if b != c]...)
+  Dict(b => filter(c -> !any(rs -> c in rs, others(b)), cs) for (b, cs) in rs)
+end
+
+function reloop_loop(cfg::CFG, blocks, entry, done, rs)
+  body = filter(b -> any(e -> e in rs[b], entry), blocks)
+  next = setdiff(blocks, body)
+  Loop(reloop(cfg, blocks = body, entry = entry, done = union(done, entry)),
+       reloop(cfg, blocks = next, entry = union([intersect(rs[b], next) for b in body]...), done = done))
+ end
+
+function reloop(cfg::CFG; blocks = 1:length(cfg.graph), entry = [1], done = Int[])
+  isempty(blocks) && return
+  rs = Dict(b => reaching(cfg, b, ignore = done) for b in blocks)
+  if length(entry) == 1 && entry[] ∉ rs[entry[]]
+    next = setdiff(blocks, entry[])
+    Simple(entry[],
+           reloop(cfg, blocks = next,
+                  entry = intersect(cfg.graph[entry[]], blocks), done = done))
+  elseif all(b -> isempty(setdiff(entry, rs[b])), entry)
+    reloop_loop(cfg, blocks, entry, done, rs)
+  elseif (rsu = reaches_unique(rs); !all(isempty, values(rsu)))
+    unique = filter(b -> !isempty(rsu[b]), entry)
+    inner = [reloop(cfg, blocks = union(b, rsu[b]), entry = [b], done = done) for b in unique]
+    next = setdiff(blocks, union([union(b, rsu[b]) for b in unique]...))
+    es = intersect(next, union(entry, reaching.((cfg,), unique)...))
+    Multiple(inner, reloop(cfg, blocks = next, entry = es, done = done))
+  else
+    reloop_loop(cfg, blocks, entry, done, rs)
+  end
+end
+
+printstructure(io::IO, ::Nothing, level) = nothing
+
+function printstructure(io::IO, s::Simple, level)
+  println(io, "  "^level, s.block)
+  printstructure(io, s.next, level)
+end
+
+function printstructure(io::IO, s::Multiple, level)
+  println(io, "  "^level, "Multiple:")
+  for b in s.inner
+    printstructure(io, b, level+1)
+  end
+  printstructure(io, s.next, level)
+end
+
+function printstructure(io::IO, s::Loop, level)
+  println(io, "  "^level, "Loop:")
+  printstructure(io, s.inner, level+1)
+  printstructure(io, s.next, level)
+end
+
+function Base.show(io::IO, b::Union{Simple,Multiple,Loop})
+  println(io, "Structured CFG:")
+  printstructure(io, b, 0)
+end

--- a/src/passes/relooper.jl
+++ b/src/passes/relooper.jl
@@ -81,30 +81,30 @@ function reloop(cfg::CFG; blocks = 1:length(cfg.graph), entry = [1], done = Int[
   end
 end
 
-const indent = "    "
+const indent = "  "
 
 printstructure(io::IO, ::Nothing, level) = nothing
+
+function printstructure(io::IO, s::Simple, level)
+  println(io, indent^level, s.block)
+  printstructure(io, s.next, level)
+end
 
 _printstructure(io::IO, s, level) = printstructure(io, s, level)
 
 function _printstructure(io::IO, s::Simple, level)
-  println(io, indent^level, s.block)
-  _printstructure(io, s.next, level)
-end
-
-function printstructure(io::IO, s::Simple, level)
-  if s.next == nothing
-    _printstructure(io, s, level)
-  else
-    println(io, indent^level, "Simple:")
-    _printstructure(io, s, level+1)
-  end
+  println(io, indent^level, "Simple:")
+  printstructure(io, s, level+1)
 end
 
 function printstructure(io::IO, s::Multiple, level)
   println(io, indent^level, "Multiple:")
-  for b in s.inner
-    printstructure(io, b, level+1)
+  if length(s.inner) == 1
+    printstructure(io, s.inner[1], level+1)
+  else
+    for b in s.inner
+      _printstructure(io, b, level+1)
+    end
   end
   printstructure(io, s.next, level)
 end
@@ -117,5 +117,5 @@ end
 
 function Base.show(io::IO, b::Union{Simple,Multiple,Loop})
   println(io, "Structured CFG:")
-  _printstructure(io, b, 0)
+  printstructure(io, b, 0)
 end

--- a/test/relooper.jl
+++ b/test/relooper.jl
@@ -1,0 +1,25 @@
+using IRTools, Test
+using IRTools: CFG, Simple, Loop, Multiple, reloop
+
+relu(x) = (y = x > 0 ? x : 0)
+
+relu_cfg = CFG(@code_ir relu(1))
+
+@test relu_cfg == CFG([[3,2],[4],[4],[]])
+
+@test reloop(relu_cfg) == Simple(1, Multiple([Simple(3), Simple(2)], Simple(4)))
+
+function pow(x, n)
+  r = 1
+  while n > 0
+    n -= 1
+    r *= x
+  end
+  return r
+end
+
+pow_cfg = CFG(@code_ir pow(2, 3))
+
+@test pow_cfg == CFG([[2],[4,3],[2],[]])
+
+@test reloop(pow_cfg) == Simple(1, Loop(Simple(2, Simple(3)), Simple(4)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,10 @@ end
   include("compiler.jl")
 end
 
+@testset "Relooper" begin
+  include("relooper.jl")
+end
+
 doctest(IRTools)
 
 end


### PR DESCRIPTION
Like #23, but splits all the CFG logic from the actual generation of expressions (todo), which should make it a bit easier to reuse in other contexts.

```julia
julia> using IRTools: @code_ir, CFG, reloop

julia> cfg = CFG(@code_ir gcd(10, 5))
CFG(Array{Int64,1}[[4, 2], [], [5], [5], [8, 6], [], [9], [9], [10], [14, 11], [13, 12], [13], [10], [16, 15], [17], [17], []])

julia> reloop(cfg)
Structured CFG:
1
Multiple:
  Simple:
    4
    5
    Multiple:
      Simple:
        8
        9
        Loop:
          10
          11
          Multiple:
            12
          13
        Multiple:
          14
        Multiple:
          Simple:
            16
          Simple:
            15
        17
      Simple:
        6
  Simple:
    2
```

Needs some docs and a PoC for generating Julia expressions.