### PR TITLE
Lambdas

### DIFF
--- a/examples/amb.jl
+++ b/examples/amb.jl
@@ -1,0 +1,52 @@
+# Implementation of the amb operator using shift/reset
+# http://community.schemewiki.org/?amb
+
+include("continuations.jl");
+
+struct Backtrack end
+
+function require(x)
+  x || throw(Backtrack())
+  return
+end
+
+unwrap(e) = e
+unwrap(e::CapturedException) = e.ex
+
+function amb(iter)
+  shift() do k
+    for x in iter
+      try
+        return k(x)
+      catch e
+        unwrap(e) isa Backtrack || rethrow()
+      end
+    end
+    throw(Backtrack())
+  end
+end
+
+function ambrun(f)
+  try
+    @reset f()
+  catch e
+    e isa Backtrack || rethrow()
+    error("No possible combination found.")
+  end
+end
+
+ambrun() do
+  x = amb([1, 2, 3])
+  y = amb([1, 2, 3])
+  require(x^2 + y == 7)
+  (x, y)
+end
+
+ambrun() do
+  N = 20
+  i = amb(1:N)
+  j = amb(i:N)
+  k = amb(j:N)
+  require(i*i + j*j == k*k)
+  (i, j, k)
+end

--- a/examples/continuations.jl
+++ b/examples/continuations.jl
@@ -1,0 +1,91 @@
+using IRTools.All
+
+function captures(ir, vs)
+  us = Set()
+  for v in vs
+    isexpr(ir[v].expr) || continue
+    foreach(x -> x isa Variable && push!(us, x), ir[v].expr.args)
+  end
+  return setdiff(us, vs)
+end
+
+rename(env, x) = x
+rename(env, x::Variable) = env[x]
+rename(env, x::Expr) = Expr(x.head, rename.((env,), x.args)...)
+rename(env, x::Statement) = stmt(x, expr = rename(env, x.expr))
+
+function continuation(ir, vs, cs, in, ret)
+  bl = empty(ir)
+  env = Dict()
+  rename(x) = Main.rename(env, x)
+  self = argument!(bl)
+  env[in] = argument!(bl)
+  for (i, c) in enumerate(cs)
+    env[c] = pushfirst!(bl, xcall(:getindex, self, i))
+  end
+  while true
+    if isempty(vs)
+      return!(bl, rename(Expr(:call, ret, returnvalue(block(ir, 1)))))
+      return bl
+    elseif isexpr(ir[vs[1]].expr, :call)
+      break
+    else
+      v = popfirst!(vs)
+      env[v] = push!(bl, rename(ir[v]))
+    end
+  end
+  v = popfirst!(vs)
+  st = ir[v]
+  cs = [ret, setdiff(captures(ir, vs), [v])...]
+  next = push!(bl, Expr(:lambda, continuation(ir, vs, cs, v, ret), rename.(cs)...))
+  ret = push!(bl, stmt(st, expr = xcall(Main, :cps, next, rename(st.expr).args...)))
+  return!(bl, ret)
+end
+
+function cpstransform(ir)
+  ir = functional(ir)
+  k = argument!(ir, at = 1)
+  bl = empty(ir)
+  env = Dict()
+  for arg in arguments(ir)
+    env[arg] = argument!(bl)
+  end
+  cs = arguments(ir)
+  cont = push!(bl, Expr(:lambda, continuation(ir, keys(ir), cs, nothing, k), rename.((env,), cs)...))
+  return!(bl, Expr(:call, cont, nothing))
+  return bl
+end
+
+cps(k, f::Core.IntrinsicFunction, args...) = k(f(args...))
+cps(k, ::typeof(cond), c, t, f) = c ? cps(k, t) : cps(k, f)
+cps(k, ::typeof(cps), args...) = k(cps(args...))
+
+@dynamo function cps(k, args...)
+  ir = IR(args...)
+  ir == nothing && return :(args[1](args[2](args[3:end]...)))
+  cpstransform(IR(args...))
+end
+
+function pow(x, n)
+  r = 1
+  while n > 0
+    n -= 1
+    r *= x
+  end
+  return r
+end
+
+cps(identity, pow, 2, 3)
+
+# shift/reset
+
+reset(f) = cps(identity, f)
+shift(f) = error("`shift` must be called inside `reset`")
+cps(k, ::typeof(shift), f) = f(k)
+
+macro reset(ex)
+  :(reset(() -> $(esc(ex))))
+end
+
+k = @reset shift(identity)^2
+k(4)

--- a/src/IRTools.jl
+++ b/src/IRTools.jl
@@ -22,6 +22,7 @@ module Inner
   include("reflection/dynamo.jl")
 
   include("passes/passes.jl")
+  include("passes/cps.jl")
   include("passes/relooper.jl")
   include("passes/stackifier.jl")
 
@@ -44,7 +45,7 @@ let exports = :[
       # Passes/Analysis
       definitions, usages, dominators, domtree, domorder, domorder!, renumber,
       merge_returns!, expand!, prune!, ssa!, inlineable!, log!, pis!, func, evalir,
-      Simple, Loop, Multiple, reloop, stackify,
+      Simple, Loop, Multiple, reloop, stackify, functional,
       # Reflection, Dynamo
       Meta, TypedMeta, meta, typed_meta, dynamo, transform, refresh, recurse!, self,
       varargs!, slots!,

--- a/src/IRTools.jl
+++ b/src/IRTools.jl
@@ -45,7 +45,7 @@ let exports = :[
       # Passes/Analysis
       definitions, usages, dominators, domtree, domorder, domorder!, renumber,
       merge_returns!, expand!, prune!, ssa!, inlineable!, log!, pis!, func, evalir,
-      Simple, Loop, Multiple, reloop, stackify, functional,
+      Simple, Loop, Multiple, reloop, stackify, functional, cond,
       # Reflection, Dynamo
       Meta, TypedMeta, meta, typed_meta, dynamo, transform, refresh, recurse!, self,
       varargs!, slots!,

--- a/src/IRTools.jl
+++ b/src/IRTools.jl
@@ -37,7 +37,7 @@ end
 
 let exports = :[
       # IR
-      IR, Block, BasicBlock, Variable, Statement, Branch, Pipe, CFG, Slot, branch, var, stmt, arguments, argtypes,
+      IRTools, IR, Block, BasicBlock, Variable, Statement, Branch, Pipe, CFG, Slot, branch, var, stmt, arguments, argtypes,
       branches, undef, unreachable, isreturn, isconditional, block!, deleteblock!, branch!, argument!, return!,
       canbranch, returnvalue, returntype, emptyargs!, deletearg!, block, blocks, successors, predecessors,
       xcall, exprtype, exprline, isexpr, insertafter!, explicitbranch!, prewalk, postwalk,
@@ -47,7 +47,7 @@ let exports = :[
       merge_returns!, expand!, prune!, ssa!, inlineable!, log!, pis!, func, evalir,
       Simple, Loop, Multiple, reloop, stackify, functional, cond,
       # Reflection, Dynamo
-      Meta, TypedMeta, meta, typed_meta, dynamo, transform, refresh, recurse!, self,
+      Meta, TypedMeta, Lambda, meta, typed_meta, dynamo, transform, refresh, recurse!, self,
       varargs!, slots!,
       ].args
   append!(exports, Symbol.(["@code_ir", "@dynamo", "@meta", "@typed_meta"]))

--- a/src/ir/ir.jl
+++ b/src/ir/ir.jl
@@ -246,6 +246,10 @@ end
 
 BasicBlock(b::Block) = b.ir.blocks[b.id]
 branches(b::Block) = branches(BasicBlock(b))
+
+branches(ir::IR) = length(blocks(ir)) == 1 ? branches(block(ir, 1)) :
+  error("IR has multiple blocks, so `branches(ir)` is ambiguous.")
+
 arguments(b::Block) = arguments(BasicBlock(b))
 arguments(ir::IR) = arguments(block(ir, 1))
 
@@ -843,6 +847,8 @@ var!(p::Pipe) = NewVariable(p.var += 1)
 substitute!(p::Pipe, x, y) = (p.map[x] = y; x)
 substitute(p::Pipe, x::Union{Variable,NewVariable}) = p.map[x]
 substitute(p::Pipe, x) = get(p.map, x, x)
+substitute(p::Pipe, x::Statement) = stmt(x, expr = substitute(p, x.expr))
+substitute(p::Pipe, x::Expr) = Expr(x.head, substitute.((p,), x.args)...)
 substitute(p::Pipe) = x -> substitute(p, x)
 
 function Pipe(ir)
@@ -876,7 +882,7 @@ function iterate(p::Pipe, (ks, b, i) = (pipestate(p.from), 1, 1))
   end
   v = ks[b][i]
   st = p.from[v]
-  substitute!(p, v, push!(p.to, prewalk(substitute(p), st)))
+  substitute!(p, v, push!(p.to, substitute(p, st)))
   ((v, st), (ks, b, i+1))
 end
 
@@ -890,7 +896,7 @@ setindex!(p::Pipe, x, v) = p.to[substitute(p, v)] = prewalk(substitute(p), x)
 
 function Base.push!(p::Pipe, x)
   tmp = var!(p)
-  substitute!(p, tmp, push!(p.to, prewalk(substitute(p), x)))
+  substitute!(p, tmp, push!(p.to, substitute(p, x)))
   return tmp
 end
 
@@ -913,7 +919,7 @@ end
 
 function insert!(p::Pipe, v, x; after = false)
   v′ = substitute(p, v)
-  x = prewalk(substitute(p), x)
+  x = substitute(p, x)
   tmp = var!(p)
   if islastdef(p.to, v′) # we can make this case efficient by renumbering
     if after
@@ -933,7 +939,7 @@ argument!(p::Pipe, a...; kw...) =
   substitute!(p, var!(p), argument!(p.to, a...; kw...))
 
 function branch!(ir::Pipe, b, args...; kw...)
-  args = map(a -> postwalk(substitute(ir), a), args)
+  args = map(a -> substitute(ir, a), args)
   branch!(blocks(ir.to)[end], b, args...; kw...)
   return ir
 end

--- a/src/ir/ir.jl
+++ b/src/ir/ir.jl
@@ -902,7 +902,7 @@ end
 
 function Base.pushfirst!(p::Pipe, x)
   tmp = var!(p)
-  substitute!(p, tmp, pushfirst!(p.to, prewalk(substitute(p), x)))
+  substitute!(p, tmp, pushfirst!(p.to, substitute(p, x)))
   return tmp
 end
 

--- a/src/ir/print.jl
+++ b/src/ir/print.jl
@@ -1,7 +1,10 @@
 import Base: show
 
 # TODO: real expression printing
-Base.show(io::IO, x::Variable) = print(io, "%", x.id)
+function Base.show(io::IO, x::Variable)
+  bs = get(io, :bindings, Dict())
+  haskey(bs, x) ? print(io, bs[x]) : print(io, "%", x.id)
+end
 
 const printers = Dict{Symbol,Any}()
 
@@ -13,12 +16,12 @@ function show(io::IO, b::Branch)
   if b == unreachable
     print(io, "unreachable")
   elseif isreturn(b)
-    print(io, "return $(repr(b.args[1]))")
+    print(io, "return ", b.args[1])
   else
     print(io, "br $(b.block)")
     if !isempty(b.args)
       print(io, " (")
-      join(io, repr.(b.args), ", ")
+      join(io, b.args, ", ")
       print(io, ")")
     end
     b.condition != nothing && print(io, " unless $(b.condition)")
@@ -39,6 +42,7 @@ end
 
 function show(io::IO, b::Block)
   indent = get(io, :indent, 0)
+  bs = get(io, :bindings, Dict())
   bb = BasicBlock(b)
   print(io, tab^indent)
   print(io, b.id, ":")
@@ -47,6 +51,7 @@ function show(io::IO, b::Block)
     printargs(io, bb.args, bb.argtypes)
   end
   for (x, st) in b
+    haskey(bs, x) && continue
     println(io)
     print(io, tab^indent, "  ")
     x == nothing || print(io, string("%", x.id), " = ")
@@ -87,7 +92,7 @@ printers[:catch] = function (io, ex)
   args = ex.args[2:end]
   if !isempty(args)
     print(io, " (")
-    join(io, repr.(args), ", ")
+    join(io, args, ", ")
     print(io, ")")
   end
 end
@@ -96,10 +101,28 @@ printers[:pop_exception] = function (io, ex)
   print(io, "pop exception $(ex.args[1])")
 end
 
+function lambdacx(io, ex)
+  bs = get(io, :bindings, Dict())
+  ir = ex.args[1]
+  args = ex.args[2:end]
+  bs′ = Dict()
+  for (v, st) in ir
+    ex = st.expr
+    if iscall(ex, GlobalRef(Base, :getindex)) &&
+        ex.args[2] == arguments(ir)[1] &&
+        ex.args[3] isa Integer
+      x = args[ex.args[3]]
+      bs′[v] = string(get(bs, x, x), "'")
+    end
+  end
+  return bs′
+end
+
 printers[:lambda] = function (io, ex)
-  io = IOContext(io, :indent=>get(io, :indent, 0)+2)
-  print(io, "λ: ")
-  printargs(io, ex.args[2:end])
+  print(io, "λ :")
+  # printargs(io, ex.args[2:end])
+  io = IOContext(io, :indent   => get(io, :indent, 0)+2,
+                     :bindings => lambdacx(io, ex))
   println(io)
   print(io, ex.args[1])
 end

--- a/src/ir/print.jl
+++ b/src/ir/print.jl
@@ -95,3 +95,11 @@ end
 printers[:pop_exception] = function (io, ex)
   print(io, "pop exception $(ex.args[1])")
 end
+
+printers[:lambda] = function (io, ex)
+  io = IOContext(io, :indent=>get(io, :indent, 0)+2)
+  print(io, "λ: ")
+  printargs(io, ex.args[2:end])
+  println(io)
+  print(io, ex.args[1])
+end

--- a/src/ir/wrap.jl
+++ b/src/ir/wrap.jl
@@ -160,7 +160,7 @@ slotname(ci, s) = Symbol(:_, s.id)
 
 function IR(ci::CodeInfo, nargs::Integer; meta = nothing)
   bs = blockstarts(ci)
-  ir = IR([ci.linetable...], meta = meta)
+  ir = IR(Core.LineInfoNode[ci.linetable...], meta = meta)
   _rename = Dict()
   rename(ex) = prewalk(ex) do x
     haskey(_rename, x) && return _rename[x]

--- a/src/passes/cps.jl
+++ b/src/passes/cps.jl
@@ -1,0 +1,63 @@
+cond(c, t, f) = c ? t() : f()
+
+allsuccs(ir, (id,chs)) =
+  union(map(b -> b.id, successors(block(ir, id))),
+        allsuccs.((ir,), chs)...)
+
+function captures(ir, (id, chs), cs = Dict())
+  bl = block(ir, id)
+  captures.((ir,), chs, (cs,))
+  cs[id] = setdiff(union([cs[i] for (i, _) in chs]..., usages(bl)), definitions(bl))
+  return cs
+end
+
+function return_thunk(x)
+  ir = IR()
+  return!(ir, xcall(:getindex, argument!(ir), 1))
+  Expr(:lambda, ir, x)
+end
+
+function functionalbranches!(bl, pr, labels)
+  if length(branches(bl)) == 1
+    br = branches(bl)[1]
+    if !isreturn(br)
+      r = push!(pr, Expr(:call, labels[br.block], br.args...))
+      empty!(branches(pr.to))
+      return!(pr, r)
+    end
+  else
+    @assert length(branches(bl)) == 2
+    f, t = branches(bl)
+    function brfunc(br)
+      isreturn(br) && return return_thunk(returnvalue(br))
+      @assert isempty(arguments(br))
+      labels[br.block]
+    end
+    r = push!(pr, xcall(IRTools, :cond, f.condition, brfunc(t), brfunc(f)))
+    empty!(branches(pr.to))
+    return!(pr, r)
+  end
+end
+
+function _functional(ir, tree, vars = [], cs = captures(ir, tree))
+  id = tree[1]
+  bl = IR(block(ir, id))
+  labels = Dict()
+  labels[id] = self = id == 1 ? arguments(bl)[1] : argument!(bl, at = 1)
+  pr = Pipe(bl)
+  for (i, v) in enumerate(vars)
+    v′ = push!(pr, xcall(:getindex, self, i))
+    v isa Integer ? (labels[v] = v′) : substitute!(pr, v, substitute(pr, v′))
+  end
+  for _ in pr end
+  for t in reverse(tree[2])
+    bs = filter(id -> haskey(labels, id), allsuccs(ir, t))
+    λ = Expr(:lambda, _functional(ir, t, [bs..., cs[t[1]]...]),
+             map(b -> labels[b], bs)..., cs[t[1]]...)
+    labels[t[1]] = push!(pr, λ)
+  end
+  functionalbranches!(bl, pr, labels)
+  return finish(pr)
+end
+
+functional(ir) = _functional(explicitbranch!(ir), domtree(ir))

--- a/src/passes/passes.jl
+++ b/src/passes/passes.jl
@@ -30,7 +30,6 @@ Base.adjoint(cfg::CFG) = transpose(cfg)
 
 function definitions(b::Block)
   defs = [Variable(i) for i = 1:length(b.ir.defs) if b.ir.defs[i][1] == b.id]
-  append!(defs, arguments(b))
 end
 
 function usages(b::Block)
@@ -72,13 +71,15 @@ function dominators(cfg; entry = 1)
   return doms
 end
 
-function domtree(cfg; entry = 1)
+function domtree(cfg::CFG; entry = 1)
   doms = dominators(cfg, entry = entry)
   doms = Dict(b => filter(c -> b != c && b in doms[c], 1:length(cfg)) for b in 1:length(cfg))
   children(b) = filter(c -> !(c in union(map(c -> doms[c], doms[b])...)), doms[b])
   tree(b) = Pair{Int,Any}(b,tree.(children(b)))
   tree(entry)
 end
+
+domtree(ir::IR; entry = 1) = domtree(CFG(ir), entry = entry)
 
 function idoms(cfg; entry = 1)
   ds = zeros(Int, length(cfg))

--- a/src/reflection/dynamo.jl
+++ b/src/reflection/dynamo.jl
@@ -7,6 +7,20 @@ end
 struct Self end
 const self = Self()
 
+# S -> function signature
+# I -> lambda index
+# T -> environment type
+struct Lambda{S,I,T}
+  data::T
+end
+
+Lambda{D,S}(data...) where {D,S} =
+  Lambda{D,S,typeof(data)}(data)
+
+@inline Base.getindex(l::Lambda, i::Integer) = l.data[i]
+
+Base.show(io::IO, l::Lambda) = print(io, "λ")
+
 function Base.showerror(io::IO, err::CompileError)
   println(io, "Error compiling @dynamo $(err.transform) on $(err.args):")
   showerror(io, err.err)
@@ -21,6 +35,24 @@ function fallthrough(args...)
        Expr(:call, [:(args[$i]) for i = 1:length(args)]...))
 end
 
+function lambdalift!(ir, S, I = ())
+  i = 0
+  for (v, st) in ir
+    isexpr(st.expr, :lambda) || continue
+    ir[v] = Expr(:call, Lambda{S,(I...,i+=1)}, st.expr.args[2:end]...)
+  end
+end
+
+function getlambda(ir, I)
+  isempty(I) && return ir
+  i = 0
+  for (v, st) in ir
+    isexpr(st.expr, :lambda) || continue
+    (i += 1) == I[1] && return getlambda(st.expr.args[1], Base.tail(I))
+  end
+  error("Something has gone wrong in IRTools; couldn't find lambda in IR")
+end
+
 # Used only for its CodeInfo
 dummy(args...) = nothing
 
@@ -32,6 +64,7 @@ function dynamo(f, args...)
   end
   ir isa Expr && return ir
   ir == nothing && return fallthrough(args...)
+  lambdalift!(ir, Tuple{f,args...}, ())
   if ir.meta isa Meta
     m = ir.meta
     ir = varargs!(m, ir)
@@ -43,6 +76,16 @@ function dynamo(f, args...)
   end
   _self = splicearg!(ir)
   prewalk!(x -> x === self ? _self : x, ir)
+  return update!(m.code, ir)
+end
+
+function dynamo_lambda(f::Type{<:Lambda{S,I}}, args...) where {S,I}
+  ir = transform(S.parameters...)
+  ir = getlambda(ir, I)
+  lambdalift!(ir, S, I)
+  closureargs!(ir)
+  m = @meta dummy(1)
+  m.code.method_for_inference_limit_heuristics = nothing
   return update!(m.code, ir)
 end
 
@@ -64,7 +107,12 @@ macro dynamo(ex)
   f, T = isexpr(name, :(::)) ?
     (length(name.args) == 1 ? (esc(gensym()), esc(name.args[1])) : esc.(name.args)) :
     (esc(gensym()), :(Core.Typeof($(esc(name)))))
-  gendef = :(@generated ($f::$T)($(esc(:args))...) where $(Ts...) = return IRTools.dynamo($f, args...))
+  gendef = quote
+    @generated ($f::$T)($(esc(:args))...) where $(Ts...) =
+      return IRTools.dynamo($f, args...)
+    @generated (f::IRTools.Inner.Lambda{<:Tuple{<:$T,Vararg{Any}}})(args...) where $(Ts...) =
+      return IRTools.Inner.dynamo_lambda(f, args...)
+  end
   quote
     $(isexpr(name, :(::)) || esc(:(function $name end)))
     function IRTools.transform(::Type{<:$T}, $(esc.(lifttype.(args))...)) where $(Ts...)

--- a/src/reflection/dynamo.jl
+++ b/src/reflection/dynamo.jl
@@ -128,9 +128,10 @@ macro code_ir(dy, ex)
   :(transform(typeof($(esc(dy))), meta($typesof($(esc(f)), $(esc.(args)...)))))
 end
 
-function recurse!(ir)
+function recurse!(ir, to = self)
   for (x, st) in ir
     isexpr(st.expr, :call) || continue
-    ir[x] = Expr(:call, self, st.expr.args...)
+    ir[x] = Expr(:call, to, st.expr.args...)
   end
+  return ir
 end

--- a/src/reflection/utils.jl
+++ b/src/reflection/utils.jl
@@ -102,6 +102,18 @@ function varargs!(meta, ir::IR, n = 0)
   return ir
 end
 
+function closureargs!(ir::IR)
+  args = arguments(ir)[2:end]
+  deletearg!(ir, 2:length(arguments(ir)))
+  argtuple = argument!(ir)
+  env = Dict()
+  for (i, a) in reverse(collect(enumerate(args)))
+    env[a] = pushfirst!(ir, xcall(:getindex, argtuple, i))
+  end
+  prewalk!(x -> get(env, x, x), ir)
+  return ir
+end
+
 # TODO this is hacky and leaves `ir.defs` incorrect
 function splicearg!(ir::IR)
   args = arguments(ir)

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -151,3 +151,20 @@ mul = func(ir)
 end
 
 @test ir_add(5, 2) == 7
+
+@dynamo function test_lambda(x)
+  λ = IR()
+  self = argument!(λ)
+  y = argument!(λ)
+  x = push!(λ, xcall(:getindex, self, 1))
+  return!(λ, xcall(:+, x, y))
+  ir = IR()
+  args = argument!(ir)
+  x = push!(ir, xcall(:getindex, args, 1))
+  return!(ir, Expr(:lambda, λ, x))
+end
+
+let
+  f = test_lambda(3)
+  @test f(6) == 9
+end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -1,6 +1,6 @@
 using IRTools, MacroTools, InteractiveUtils, Test
 using IRTools: @dynamo, IR, meta, isexpr, xcall, self, insertafter!, recurse!,
-  argument!, return!, func, var
+  argument!, return!, func, var, functional
 
 @dynamo roundtrip(a...) = IR(a...)
 
@@ -168,3 +168,13 @@ let
   f = test_lambda(3)
   @test f(6) == 9
 end
+
+anf(f::Core.IntrinsicFunction, args...) = f(args...)
+
+@dynamo function anf(args...)
+  ir = IR(args...)
+  ir == nothing && return
+  functional(recurse!(ir, anf))
+end
+
+@test anf(pow, 2, 3) == 8


### PR DESCRIPTION
An in-IR representation of closures/lamdbas. The main goal is that it's useful for external IRs which make use of lambdas for control flow (e.g. ONNX, XLA, Myia), though this could also dovetail nicely with first-class closure support in Julia's compiler too (https://github.com/JuliaLang/julia/pull/31253).

```julia
ir = IR()
x = argument!(ir)

t_block = IR()
return!(t_block, xcall(:getindex, argument!(t_block), 1))
t = push!(ir, Expr(:lambda, t_block, x))

f_block = IR()
return!(f_block, xcall(:zero, xcall(:getindex, argument!(f_block), 1)))
f = push!(ir, Expr(:lambda, f_block, x))

push!(ir, xcall(:ifelse, xcall(:>, x, 0), t, f))
```

produces:

```julia
1: (%1)
  %2 = λ: (%1)
    1: (%1)
      %2 = Base.getindex(%1, 1)
      return %2

  %3 = λ: (%1)
    1: (%1)
      %2 = Base.getindex(%1, 1)
      %3 = Base.zero(%2)
      return %3

  %4 = %1 > 0
  %5 = Base.ifelse(%4, %2, %3)
```

The semantics are that the tuple of values in `λ: (...)` get passed, as a tuple, as the lambda's first argument. So in this case the lambdas are zero-argument thunks, and the `getindex` calls are retrieving the original input `x`.

I could imagine coming up with nicer syntax sugar / printing for this (e.g. maybe `%x'` asks for `x` in the enclosing scope) but for now this is OK. We just need some tests (might need to finally implement that interpreter for those).