### PR TITLE
Try/catch handling

### DIFF
--- a/src/ir/ir.jl
+++ b/src/ir/ir.jl
@@ -442,6 +442,7 @@ deletearg!(ir::IR, i) = deletearg!(block(ir, 1), i)
 Return the `i`-th `Block` of `ir`.
 """
 block(ir::IR, i) = Block(ir, i)
+block(ir::IR, v::Variable) = blockidx(ir, v)[1]
 
 """
     blocks(ir)
@@ -541,6 +542,8 @@ function Base.delete!(ir::IR, i::Variable)
   ir.defs[i.id] = (-1, -1)
   return ir
 end
+
+Base.delete!(b::Block, i::Variable) = delete!(b.ir, i)
 
 length(b::Block) = count(x -> x[1] == b.id, b.ir.defs)
 
@@ -715,6 +718,9 @@ function insert!(ir::IR, i::Variable, x; after = false)
     insert!(b, i+after, x)
   end
 end
+
+insert!(b::Block, i::Variable, x; after = false) =
+  insert!(b.ir, i, x; after = after)
 
 """
     insertafter!(ir, v, x)

--- a/src/ir/print.jl
+++ b/src/ir/print.jl
@@ -3,6 +3,10 @@ import Base: show
 # TODO: real expression printing
 Base.show(io::IO, x::Variable) = print(io, "%", x.id)
 
+const printers = Dict{Symbol,Any}()
+
+print_stmt(io::IO, ex::Expr) = get(printers, ex.head, print)(io, ex)
+
 print_stmt(io::IO, ex) = print(io, ex)
 
 function show(io::IO, b::Branch)
@@ -68,4 +72,26 @@ function print_stmt(io::IO, ex::IR)
   io = IOContext(io, :indent=>get(io, :indent, 0)+2)
   println(io)
   show(io, ex)
+end
+
+printers[:enter] = function (io, ex)
+  print(io, "try #$(ex.args[1])")
+end
+
+printers[:leave] = function (io, ex)
+  print(io, "end try")
+end
+
+printers[:catch] = function (io, ex)
+  print(io, "catch $(ex.args[1])")
+  args = ex.args[2:end]
+  if !isempty(args)
+    print(io, " (")
+    join(io, repr.(args), ", ")
+    print(io, ")")
+  end
+end
+
+printers[:pop_exception] = function (io, ex)
+  print(io, "pop exception $(ex.args[1])")
 end

--- a/src/ir/wrap.jl
+++ b/src/ir/wrap.jl
@@ -175,6 +175,8 @@ function IR(ci::CodeInfo, nargs::Integer; meta = nothing)
     ex = ci.code[i]
     if ex isa Core.NewvarNode
       continue
+    elseif isexpr(ex, :enter)
+      push!(ir, Expr(:enter, findfirst(==(ex.args[1]), bs)+1))
     elseif isexpr(ex, GotoNode)
       branch!(ir, findfirst(==(ex.label), bs)+1)
     elseif isexpr(ex, :gotoifnot)

--- a/src/ir/wrap.jl
+++ b/src/ir/wrap.jl
@@ -176,7 +176,7 @@ function IR(ci::CodeInfo, nargs::Integer; meta = nothing)
     if ex isa Core.NewvarNode
       continue
     elseif isexpr(ex, :enter)
-      push!(ir, Expr(:enter, findfirst(==(ex.args[1]), bs)+1))
+      _rename[Core.SSAValue(i)] = push!(ir, Expr(:enter, findfirst(==(ex.args[1]), bs)+1))
     elseif isexpr(ex, GotoNode)
       branch!(ir, findfirst(==(ex.label), bs)+1)
     elseif isexpr(ex, :gotoifnot)

--- a/src/reflection/utils.jl
+++ b/src/reflection/utils.jl
@@ -18,6 +18,16 @@ function slots!(ir::IR)
       empty!(BasicBlock(b).args)
       empty!(BasicBlock(b).argtypes)
     end
+    # Catch branches
+    for (v, st) in b
+      isexpr(st.expr, :catch) || continue
+      target = st.expr.args[1]
+      args   = st.expr.args[2:end]
+      for (i, val) in enumerate(args)
+        insert!(b, v, :($(phislot(target, i)) = $val))
+      end
+      delete!(b, v)
+    end
     # Branches
     for br in BasicBlock(b).branches
       isreturn(br) && continue

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -33,6 +33,31 @@ foo(x) = y = x > 0 ? x + 1 : x - 1
 
 @test passthrough(() -> [1, 2, 3]) == [1, 2, 3]
 
+function err(f)
+  try
+    f()
+  catch e
+    e
+  end
+end
+
+@test passthrough(err, () -> 2+2) == 4
+@test passthrough(err, () -> 0//0) isa ArgumentError
+
+function err2(f)
+    x = 1
+    y = 1
+    try
+        y = f()
+    catch e
+      x, y
+    end
+    x, y
+end
+
+@test passthrough(err2, () -> 2+2) == (1, 4)
+@test passthrough(err2, () -> 0//0) == (1, 1)
+
 @dynamo function mullify(a...)
   ir = IR(a...)
   ir == nothing && return


### PR DESCRIPTION
Representing try/catch in SSA form, and converting it back to the usual lowered-code form for code generation.

Previously IRTools had no notion of try/catch at all. I never tested this but presumably it blew up badly in those cases. Now try/catch works great with dynamos and tools like Zygote can handle it as they wish.

Example usage with interesting dataflow:

```julia
julia> function foo()
         x = 1
         y = 1
         try
           y = bar()
         catch e
           x, y
         end
         x, y
       end
foo (generic function with 2 methods)

julia> @code_ir foo()
1: (%1)
  %2 = try #2
  %3 = catch 2 (1, 1)
  %4 = Main.bar()
  %5 = catch 2 (1, %4)
  %6 = end try
  br 3 (1, %4)
2: (%7, %8)
  %9 = end try
  %10 = $(Expr(:the_exception))
  %11 = Core.tuple(%7, %8)
  %12 = pop exception %2
  br 3 (%7, %8)
3: (%13, %14)
  %15 = Core.tuple(%13, %14)
  return %15
```

`try` and `end try` correspond to the usual `enter` and `leave`. `catch` is a pseudo-branch that says "if an error is thrown after this point, branch to `#2` with the following arguments". Those argument can change over the course of the try block, so multiple catch branches are allowed.