### PR TITLE
Update dynamo refresh warning

### DIFF
--- a/docs/src/dynamo.md
+++ b/docs/src/dynamo.md
@@ -277,7 +277,7 @@ julia> c.count
 
 !!! warning
 
-    On Julia versions older than 1.3, a current usability issue with the dynamo is that it is _not_ automatically updated when you redefine functions. For example:
+    On Julia versions older than 1.3, dynamos are _not_ automatically updated when you redefine functions. For example:
 
     ```julia
     julia> @dynamo roundtrip(a...) = IR(a...)

--- a/docs/src/dynamo.md
+++ b/docs/src/dynamo.md
@@ -277,7 +277,7 @@ julia> c.count
 
 !!! warning
 
-    A current usability issue with the dynamo is that it is _not_ automatically updated when you redefine functions. For example:
+    On Julia versions older than 1.3, a current usability issue with the dynamo is that it is _not_ automatically updated when you redefine functions. For example:
 
     ```julia
     julia> @dynamo roundtrip(a...) = IR(a...)
@@ -303,3 +303,5 @@ julia> c.count
     julia> roundtrip(foo, 5)
     6
     ```
+    
+    On versions newer than 1.3, `IRTools.refresh` is not required. 

--- a/docs/src/dynamo.md
+++ b/docs/src/dynamo.md
@@ -304,4 +304,4 @@ julia> c.count
     6
     ```
     
-    On versions newer than 1.3, `IRTools.refresh` is not required. 
+    With Julia 1.3 and later, `IRTools.refresh` is not required. 


### PR DESCRIPTION
The caveat about needing `IRTools.refresh` isn't needed on 1.3. Not sure if there are additional caveats that should be put in though
```
julia> VERSION
v"1.3.1"

julia> @dynamo roundtrip(a...) = IR(a...)

julia> foo(x) = x^2
foo (generic function with 1 method)

julia> roundtrip(foo, 5)
25

julia> foo(x) = x+1
foo (generic function with 1 method)

julia> roundtrip(foo, 5)
6
```