### PR TITLE
Smarter fallthrough

### DIFF
--- a/src/reflection/dynamo.jl
+++ b/src/reflection/dynamo.jl
@@ -15,6 +15,12 @@ end
 function transform end
 function refresh end
 
+function fallthrough(args...)
+  Expr(:block,
+       Expr(:meta, :inline),
+       Expr(:call, [:(args[$i]) for i = 1:length(args)]...))
+end
+
 function dynamo(f, args...)
   try
     ir = transform(f, args...)::Union{IR,Expr,Nothing}
@@ -22,7 +28,7 @@ function dynamo(f, args...)
     rethrow(CompileError(f, args, e))
   end
   ir isa Expr && return ir
-  ir == nothing && return :(args[1](args[2:end]...))
+  ir == nothing && return fallthrough(args...)
   m = ir.meta::Meta
   ir = varargs!(m, ir)
   argnames!(m, :args)


### PR DESCRIPTION
@masonprotter found that intrinsics don't infer well if you recurse over them, meaning that a `roundtrip` like this one would significantly slow down code in some cases. This was just because our current fallback had a bunch of splatting which, it turns out, was not elided by the compiler. Explicitly unrolling the splat and forcing inlining makes the `roundtrip` version of `f` perform identically to the original.

```julia
using IRTools: IRTools, @dynamo, IR, recurse!
using BenchmarkTools

@dynamo function roundtrip(a...)
    ir = IR(a...)
    ir == nothing && return
    recurse!(ir)
    return ir
end

f(x) = x + 1

roundtrip(f, 1)
```