### PR TITLE
Help Julia do type narrowing

### DIFF
--- a/src/ir/ir.jl
+++ b/src/ir/ir.jl
@@ -538,6 +538,8 @@ function setindex!(ir::IR, x, i::Variable)
   b[i] = x
 end
 
+setindex!(b::Block, x, i::Variable) = setindex!(b.ir, x, i)
+
 function Base.delete!(ir::IR, i::Variable)
   ir[i] = nothing
   ir.defs[i.id] = (-1, -1)

--- a/src/reflection/utils.jl
+++ b/src/reflection/utils.jl
@@ -38,7 +38,13 @@ function slots!(ir::IR)
     for br in BasicBlock(b).branches
       isreturn(br) && continue
       for (i, val) in enumerate(br.args)
-        push!(b, :($(phislot(br.block, i)) = $val))
+        ϕ = phislot(br.block, i)
+        if val in keys(b) && !isexpr(b[val].expr, :(=))
+          b[val] = :($ϕ = $(b[val].expr))
+          slots[val] = ϕ
+        else
+          push!(b, :($ϕ = $val))
+        end
       end
       empty!(br.args)
     end


### PR DESCRIPTION
```julia
using LinearAlgebra, IRTools, BenchmarkTools
using IRTools: IR, @dynamo

@dynamo function pass(f, x)
  ir = IR(f, x)
  return ir
end

A = rand(100, 100)
```
```julia
julia> @btime tr($A)
  77.351 ns (0 allocations: 0 bytes)
49.604880105076276

julia> @btime pass(tr, $A)
  78.095 ns (0 allocations: 0 bytes)
49.604880105076276
```

cc @roger-luo