### PR TITLE
support finding dependencies of a variable

### DIFF
--- a/src/ir/utils.jl
+++ b/src/ir/utils.jl
@@ -80,3 +80,29 @@ function exprline(ir::IR, x::Variable)
   i > 0 || return
   get(ir.lines, ir[x].line, nothing)
 end
+
+function dependencies(ir::IR, x::IRTools.Variable)
+  var_stack = Variable[x]
+  path = Variable[]
+  args = IRTools.arguments(ir)
+  while !isempty(var_stack)
+      curr_var = pop!(var_stack)
+      if curr_var in args
+          continue
+      end
+
+      stmt = ir[curr_var]
+      if (stmt.expr isa Expr) && (stmt.expr.head == :call)
+          for arg in  stmt.expr.args
+              if arg isa Variable
+                  # skip nodes we visited
+                  if !(arg in path)
+                      push!(var_stack, arg)
+                      push!(path, arg)
+                  end
+              end
+          end
+      end        
+  end
+  return path
+end


### PR DESCRIPTION
I think we discuss this a long time ago in slack @MikeInnes , by dispatching `pullback`s or other contextual calls to only variables dependent on the result, it will at least eliminate some annoying errors for functions that does not involve global references etc.

but I'm not sure this is the right way to implement it. I guess you might have some comments. especially, I'm not sure this is right for branches.