### PR TITLE
support do blocks in @code_ir

### DIFF
--- a/src/reflection/reflection.jl
+++ b/src/reflection/reflection.jl
@@ -118,8 +118,13 @@ function code_ir(f, T)
 end
 
 function code_irm(ex)
-  isexpr(ex, :call) || error("@code_ir f(args...)")
-  f, args = ex.args[1], ex.args[2:end]
+  if isexpr(ex, :call)
+    f, args = ex.args[1], ex.args[2:end]
+  elseif isexpr(ex, :do)
+    f, args = ex.args[1].args[1], vcat(ex.args[2], ex.args[1].args[2:end])
+  else
+    error("@code_ir f(args...)")
+  end
   :($code_ir($(esc(f)), typesof($(esc.(args)...))))
 end
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -6,3 +6,7 @@ using IRTools: Meta, meta
 @test meta(Tuple{typeof(gcd),Int,Int}) isa Meta
 
 @test meta(Tuple{typeof(f),Int}) isa Meta
+
+@test @code_ir(map([1,2], [3,4]) do x, y
+  x + y
+end) isa IR


### PR DESCRIPTION
```julia
julia> @code_ir map([1,2], [3,4]) do x, y
           x + y
       end
1: (%1, %2, %3)
  %4 = Core.tuple(%2)
  %5 = Core._apply_iterate(Base.iterate, Base.Generator, %4, %3)
  %6 = Base.collect(%5)
  return %6
```
I think this is worth having because with a lot of dynamos, one wants to write them with `do` block syntax, but then you can't easily look at their `@code_ir`. 