### PR TITLE
Inlining

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -38,6 +38,7 @@ IRTools.branch!
 IRTools.return!
 IRTools.successors
 IRTools.predecessors
+IRTools.inline
 keys
 haskey
 push!

--- a/src/IRTools.jl
+++ b/src/IRTools.jl
@@ -25,6 +25,7 @@ module Inner
   include("reflection/dynamo.jl")
 
   include("passes/passes.jl")
+  include("passes/inline.jl")
   include("passes/cps.jl")
   include("passes/relooper.jl")
   include("passes/stackifier.jl")
@@ -46,7 +47,7 @@ let exports = :[
       definitions, usages, dominators, domtree, domorder, domorder!, renumber,
       merge_returns!, expand!, prune!, ssa!, inlineable!, log!, pis!, func, evalir,
       Simple, Loop, Multiple, reloop, stackify, functional, cond, WorkQueue,
-      Graph, liveness, interference, colouring,
+      Graph, liveness, interference, colouring, inline,
       # Reflection, Dynamo
       Meta, Lambda, meta, dynamo, transform, refresh, recurse!, self,
       varargs!, slots!,

--- a/src/ir/ir.jl
+++ b/src/ir/ir.jl
@@ -960,3 +960,13 @@ function branch!(ir::Pipe, b, args...; kw...)
   branch!(blocks(ir.to)[end], b, args...; kw...)
   return ir
 end
+
+function block!(p::Pipe)
+  block!(p.to)
+  return
+end
+
+function blockargument!(p::Pipe, type)
+  x = argument!(blocks(p.to)[end], nothing, type, insert = false)
+  substitute!(p, var!(p), x)
+end

--- a/src/passes/inline.jl
+++ b/src/passes/inline.jl
@@ -1,0 +1,44 @@
+function inlinehere!(ir, source, args...)
+  source = merge_returns!(copy(source)) # TODO preserve type info
+  env = Dict()
+  retvalue = nothing
+  rename(x::Variable) = env[x]
+  rename(x::Expr) = Expr(x.head, rename.(x.args)...)
+  rename(x::Statement) = stmt(x, expr = rename(x.expr))
+  rename(x) = x
+  for (name, arg) in zip(arguments(source), args)
+    env[name] = arg
+  end
+  for bl in blocks(source)
+    if bl.id != 1
+      block!(ir)
+      for (arg, T) in zip(arguments(bl), argtypes(bl))
+        env[arg] = blockargument!(ir, T)
+      end
+    end
+    for (v, st) in bl
+      env[v] = push!(ir, rename(st))
+    end
+    for br in branches(bl)
+      if isreturn(br)
+        retvalue = rename(returnvalue(br))
+      else
+        branch!(ir, br.block, rename.(br.args)..., unless = br.condition)
+      end
+    end
+  end
+  return retvalue
+end
+
+function inline(ir::IR, loc::Variable, source::IR)
+  pr = Pipe(ir)
+  for (v, st) in pr
+    if v === loc
+      ex = ir[loc].expr
+      delete!(pr, v)
+      v′ = inlinehere!(pr, source, ex.args...)
+      substitute!(pr, v, substitute(pr, v′))
+    end
+  end
+  return finish(pr)
+end

--- a/src/passes/inline.jl
+++ b/src/passes/inline.jl
@@ -30,6 +30,29 @@ function inlinehere!(ir, source, args...)
   return retvalue
 end
 
+"""
+    inline(ir, location, source)
+
+Replace the function call at `ir[location]` with the IR `source`. The inlined IR
+will use the function arguments at `ir[location]` as its input.
+
+```
+julia> foo(x, y) = max(x, y)+1
+
+julia> ir = @code_ir foo(1, 1)
+1: (%1, %2, %3)
+  %4 = Main.max(%2, %3)
+  %5 = %4 + 1
+  return %5
+
+julia> inline(ir, var(4), @code_ir(max(1,1)))
+1: (%1, %2, %3)
+  %4 = %3 < %2
+  %5 = Base.ifelse(%4, %2, %3)
+  %6 = %5 + 1
+  return %6
+```
+"""
 function inline(ir::IR, loc::Variable, source::IR)
   pr = Pipe(ir)
   for (v, st) in pr

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -32,3 +32,18 @@ end
 mylog2(x) = ccall((:log2, Base.Math.libm), Float64, (Float64,), x)
 
 @test foo(mylog2, 3.3) === mylog2(3.3)
+
+bar(a, b) = a > b ? a : b
+
+function foo(a, b)
+  bar(a, b)
+end
+
+let
+  ir1 = @code_ir foo(1, 2)
+  ir2 = @code_ir bar(1, 2)
+  ir = IRTools.inline(ir1, IRTools.var(4), ir2)
+  f = IRTools.func(ir)
+  @test f(nothing, 2, 3) == 3
+  @test f(nothing, 3, 2) == 3
+end


### PR DESCRIPTION
Ability to inline one piece of IR into another.

This isn't as clean as I'd like it to be. In particular we should really factor out the `rename` pattern (which gets reused everywhere) and clean up the `Pipe` API. `substitute` was meant to be internal but ends up being quite common; we also need to be able to refer to new/old blocks, I think. Ideally `inline`, and really everything in `passes`, should use only the public IRTools API.