### PR TITLE
Add some explicit world age increments

### DIFF
--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -370,7 +370,8 @@ end
     @test fir(nothing, false, 1) === 11
 
     ir = @code_ir f_try_catch7()
-    @test func(ir)(nothing) === 1.
+    fir = func(ir)
+    @test fir(nothing) === 1.
 
     ir = @code_ir f_try_catch8(1.)
     fir = func(ir)

--- a/test/ir.jl
+++ b/test/ir.jl
@@ -49,8 +49,8 @@ let
   @test inline_at !== nothing
   ir = IRTools.inline(ir1, inline_at, ir2)
   f = IRTools.func(ir)
-  @test f(nothing, 2, 3) == 3
-  @test f(nothing, 3, 2) == 3
+  @test invokelatest(f, nothing, 2, 3) == 3
+  @test invokelatest(f, nothing, 3, 2) == 3
 end
 
 function foo1(x)
@@ -77,8 +77,8 @@ let
   end
   @test inline_at !== nothing
   ir3 = IRTools.inline(ir, inline_at, ir2)
-  @test IRTools.func(ir3)(nothing, 2) == 12
-  @test IRTools.func(ir3)(nothing, 101) == 101
+  @test invokelatest(IRTools.func(ir3), nothing, 2) == 12
+  @test invokelatest(IRTools.func(ir3), nothing, 101) == 101
 end
 
 
@@ -103,6 +103,6 @@ let
   end
   @test inline_at !== nothing
   ir3 = IRTools.inline(ir, inline_at, ir2)
-  @test IRTools.func(ir3)(nothing, 2) == foo2(2)
-  @test IRTools.func(ir3)(nothing, -2) == foo2(-2)
+  @test invokelatest(IRTools.func(ir3), nothing, 2) == foo2(2)
+  @test invokelatest(IRTools.func(ir3), nothing, -2) == foo2(-2)
 end


### PR DESCRIPTION
Julia 1.12 will be stricter about implicit world age increments at toplevel and these annotations may be required (and are harmless on older julia versions). See https://github.com/JuliaLang/julia/pull/56509.

[Please delete this text and describe your change here.
For bugfixes, please detail the bug and include a test case which your patch fixes.
If you are adding a new feature, please clearly describe the design, its rationale, the possible alternatives considered.
It is easiest to merge new features when there is clear precedent in other systems; we need to know we're taking
the right direction since it can be hard to change later.]

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable
