### PR TITLE
Import `typesof` from Base instead of InteractiveUtils

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IRTools"
 uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.4.14"
+version = "0.4.15"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/reflection/reflection.jl
+++ b/src/reflection/reflection.jl
@@ -1,6 +1,6 @@
 using Core: CodeInfo, Typeof
 using Core.Compiler: InferenceState, MethodInstance, svec
-using InteractiveUtils: typesof
+using Base: typesof
 
 if isdefined(Base, :hasgenerator) # VERSION >= v"1.7.0"
   hasgenerator(x) = Base.hasgenerator(x)


### PR DESCRIPTION
`typesof` was defined in Base, and simply used by InteractiveUtils. https://github.com/JuliaLang/julia/pull/57909 removed the `using` statement from InteractiveUtils, breaking the import. This PR fixes that.