### PR TITLE
Fix lost-copy when lowering permuted block arguments to slots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IRTools"
 uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.4.15"
+version = "0.4.16"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/reflection/utils.jl
+++ b/src/reflection/utils.jl
@@ -12,6 +12,36 @@ end
 
 phislot(b, i) = Slot(Symbol(:phi_, b, :_, i))
 
+sloteq(a, b) = a isa Slot && b isa Slot && a.id === b.id
+
+# Lower a parallel copy `dests .= srcs` (block-argument passing) into a sequence
+# of scalar assignments appended to block `b`. Naively emitting `dest_i = src_i`
+# in order is wrong when a destination slot is also used as a source (e.g. the
+# swap `a, b = b, a` produced by a loop), because an earlier assignment clobbers
+# a value a later one still needs. We therefore emit moves in a safe order,
+# breaking cycles by spilling a destination to a fresh temporary first.
+function copyargs!(b, dests, srcs)
+  srcs = collect(Any, srcs)
+  todo = [i for i = 1:length(dests) if !sloteq(dests[i], srcs[i])]
+  while !isempty(todo)
+    k = findfirst(i -> !any(j -> sloteq(srcs[j], dests[i]), todo), todo)
+    if k === nothing
+      # Only cycles remain; break one by saving a destination to a temporary.
+      i = first(todo)
+      tmp = Slot(gensym(:copy))
+      push!(b, :($tmp = $(dests[i])))
+      for j in todo
+        sloteq(srcs[j], dests[i]) && (srcs[j] = tmp)
+      end
+    else
+      i = todo[k]
+      push!(b, :($(dests[i]) = $(srcs[i])))
+      deleteat!(todo, k)
+    end
+  end
+  return b
+end
+
 # TODO: handle undef arguments properly.
 function slots!(ir::IR)
   slots = Dict()
@@ -37,10 +67,11 @@ function slots!(ir::IR)
     # Branches
     for br in BasicBlock(b).branches
       isreturn(br) && continue
-      for (i, val) in enumerate(br.args)
-        ϕ = phislot(br.block, i)
-        push!(b, :($ϕ = $val))
-      end
+      dests = [phislot(br.block, i) for i = 1:length(br.args)]
+      # Resolve sources to the slots they will become, so that cycles introduced
+      # by block-argument permutations (e.g. swaps) can be detected and broken.
+      srcs = [get(slots, a, a) for a in br.args]
+      copyargs!(b, dests, srcs)
       empty!(br.args)
     end
   end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -40,6 +40,28 @@ foo(x) = y = x > 0 ? x + 1 : x - 1
 
 @test passthrough(() -> [1, 2, 3]) == [1, 2, 3]
 
+# Loop-carried variables that permute on a back-edge lower to a parallel copy of
+# block arguments; sequentialising it naively drops values (FluxML/Zygote.jl#1198).
+function swap_loop(x, y, n)
+  for _ in 1:n
+    x, y = y, x
+  end
+  return x
+end
+for n in 0:5
+  @test roundtrip(swap_loop, 10, 20, n) == swap_loop(10, 20, n)
+end
+
+function rotate_loop(a, b, c, n)
+  for _ in 1:n
+    a, b, c = b, c, a
+  end
+  return (a, b, c)
+end
+for n in 0:6
+  @test roundtrip(rotate_loop, 1, 2, 3, n) == rotate_loop(1, 2, 3, n)
+end
+
 function err(f)
   try
     f()


### PR DESCRIPTION
## Problem

`slots!` lowers each branch's block-argument passing into a sequence of scalar
assignments `phi_target_i = arg_i`, emitted in index order:

```julia
for (i, val) in enumerate(br.args)
  ϕ = phislot(br.block, i)
  push!(b, :($ϕ = $val))
end
```

This is a **parallel copy** (all the target block's parameters are assigned
simultaneously), but it is lowered as a **sequential** one. When a branch
permutes its target block's own parameters — e.g. a loop-carried swap
`a, b = b, a`, whose back-edge passes the two slots in swapped positions — an
earlier assignment clobbers a slot that a later assignment still needs:

```
phi_2_2 = phi_2_3   # a = b
phi_2_3 = phi_2_2   # b = a  ← reads the already-overwritten slot → b = b
```

so both end up holding the same value and the swap is silently lost.

### Minimal reproduction

```julia
using IRTools: @dynamo, IR
@dynamo roundtrip(a...) = IR(a...)

function swap_loop(x, y, n)
    for _ in 1:n
        x, y = y, x
    end
    return x
end

roundtrip(swap_loop, 10, 20, 3)   # returned 10, should be 20
```

## Fix

Sequentialise each branch's block arguments as a proper parallel copy, emitting
moves in a safe order and breaking cycles (swaps, rotations, …) by spilling a
destination to a fresh temporary first:

```
@tmp    = phi_2_2   # save a
phi_2_2 = phi_2_3   # a = b
phi_2_3 = @tmp      # b = saved a   ✓
```

Sources are resolved through the `slots` map before comparison so that the
cycle introduced by a permutation can be detected.

## Why this matters

This is the root cause of [FluxML/Zygote.jl#1198](https://github.com/FluxML/Zygote.jl/issues/1198)
("Incorrect function evaluation when swapping variables"). Zygote's reverse pass
turns a loop that rotates buffers (`v0, v1, v2 = v1, v2, v0`) into an adjoint
loop that swaps two block arguments each iteration; the lost copy dropped the
gradient seed, producing a silent `nothing`/wrong gradient.

## Tests

Added `roundtrip` regression tests in `test/compiler.jl` covering a 2-cycle
(swap) and a 3-cycle (rotation) carried across loop iterations. Both fail on
`master` and pass with this change.

Validation:
- IRTools test suite: no new failures vs. `master` baseline (pre-existing
  Julia 1.12 line-info / world-age failures are unchanged).
- Downstream Zygote: `compiler.jl`, `features.jl`, and `gradcheck_p1.jl` pass;
  the Zygote#1198 reproduction now matches finite differences for both the
  primal value and the gradient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)