### PR TITLE
Only inline bare `GlobalRef` statements on Julia 1.12+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IRTools"
 uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.4.16"
+version = "0.4.17"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/ir/wrap.jl
+++ b/src/ir/wrap.jl
@@ -189,11 +189,17 @@ function IR(ci::CodeInfo, nargs::Integer; meta = nothing)
               unless = rename(cond))
     elseif isreturn(ex)
       return!(ir, rename(retval(ex)))
-    elseif ex isa GlobalRef
+    elseif ex isa GlobalRef && VERSION >= v"1.12.0-DEV.173"
       # As of Julia 1.12, lowering hoists the callee of a call into its own
       # statement (e.g. `%4 = Main.:*; %5 = (%4)(%2, %3)`). Inline such bare
       # `GlobalRef` statements back into their use sites so the IR retains the
       # shape it had on earlier versions (`%4 = %2 * %3`).
+      #
+      # This must stay gated to versions that actually hoist: on <1.12, lowering
+      # never emits a bare `GlobalRef` statement, but downstream IR producers
+      # (e.g. Zygote's forward-mode dynamo) can, and inlining those reshapes the
+      # IR in a way that breaks them (Zygote's nested `pushforward` recursed
+      # without terminating on Julia 1.10).
       _rename[Core.SSAValue(i)] = ex
     else
       _rename[Core.SSAValue(i)] = push!(ir, IRTools.stmt(rename(ex), line = codelocs[i]))


### PR DESCRIPTION
## Summary

The `GlobalRef` branch in `IR(::CodeInfo, ...)` ([`src/ir/wrap.jl`](https://github.com/FluxML/IRTools.jl/blob/master/src/ir/wrap.jl)) inlines bare `GlobalRef` statements into their use sites. It was added in #134 to undo Julia 1.12's lowering change, which hoists a call's callee into its own statement:

```julia
# Julia 1.12 lowers `a * b` to:
%1 = Main.:*
%2 = (%1)(_2, _3)
# IRTools folds it back to the pre-1.12 shape:
%2 = _2 * _3
```

The branch was **unconditional**, so it also ran on Julia 1.10/1.11. There, `code_lowered` never produces a bare `GlobalRef` statement — but downstream IR producers do. In particular **Zygote's forward-mode dynamo** emits bare `GlobalRef` statements, and folding those into their uses reshapes the IR enough that the dynamo's recursion stops terminating, blowing the stack with a `StackOverflowError`.

This surfaced as a CI failure in Zygote on Julia 1.10 after it bumped to IRTools 0.4.16 (FluxML/Zygote.jl#1638): nested forward-mode AD (`pushforward` of `pushforward`) recurses infinitely through `literal_indexed_iterate`.

## Fix

Gate the branch behind `VERSION >= v"1.12.0-DEV.173"` — the same boundary already used for the 1.12 debug-info handling in this file — so pre-1.12 behaviour is exactly as it was before #134.

## Validation

- Reproduced the Zygote `StackOverflowError` on Julia 1.10 with registered IRTools 0.4.16; confirmed it disappears with this change while unrelated Zygote code is untouched.
- IRTools test suite passes on Julia 1.10 and 1.12.
- Zygote forward-mode tests + full Zygote suite pass on Julia 1.10 and 1.12 against this branch.
- Verified empirically that Julia 1.12 hoists callees (so the branch is still needed there) and Julia 1.10 does not (so it must not fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)