### PR TITLE
Fix SSA conversion of `isdefined` on conditionally-defined locals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IRTools"
 uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
 authors = ["Mike J Innes <mike.j.innes@gmail.com>"]
-version = "0.4.17"
+version = "0.4.18"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/passes/passes.jl
+++ b/src/passes/passes.jl
@@ -206,6 +206,19 @@ struct CatchBranch
     v::Variable
 end
 
+# Definedness of a slot's reaching value `r`, for translating `Expr(:isdefined, slot)`.
+# A possibly-undefined slot becomes a block argument that carries the `Undefined()`
+# sentinel at run time when the slot was never assigned, so:
+#   * `r === undef`   -- statically never defined (e.g. reached the entry block with
+#                        no definition)             -> `false`
+#   * `r isa Variable` -- an SSA value or block argument that may be the sentinel
+#                        at run time                 -> `!(r isa Undefined)`
+#   * otherwise       -- a concrete constant, always defined -> `true`
+definedness(r) =
+  r === undef ? false :
+  r isa Variable ? xcall(:!, xcall(Core, :isa, r, Undefined)) :
+  true
+
 function ssa!(ir::IR)
   current = 1
   defs = Dict(b => Dict{Slot,Any}() for b in 1:length(ir.blocks))
@@ -282,7 +295,17 @@ function ssa!(ir::IR)
   end
   for b in blocks(ir)
     current = b.id
-    rename(ex) = prewalk(x -> x isa Slot ? reaching(b, x) : x, ex)
+    rename(ex) = prewalk(ex) do x
+      if x isa Slot
+        reaching(b, x)
+      elseif isexpr(x, :isdefined) && length(x.args) == 1 && x.args[1] isa Slot
+        # `isdefined` must not be renamed like an ordinary use: substituting the
+        # slot with its reaching value discards the definedness information.
+        definedness(reaching(b, x.args[1]))
+      else
+        x
+      end
+    end
     for (v, st) in b
       ex = st.expr
       if isexpr(ex, :(=)) && ex.args[1] isa Slot

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -400,3 +400,25 @@ end
     @test fir(nothing, 1.) == log(1. - log(2.))
     @test fir(nothing, -1.) == 1.
 end
+
+# `@isdefined` on a conditionally-defined local. SSA conversion turns the slot into
+# a block argument carrying `Undefined()` when unassigned, so `isdefined` must test
+# for that rather than substituting the slot's value (which is always "defined").
+function f_isdefined(x)
+    local y
+    x > 0 && (y = 3x)
+    @isdefined(y) ? y : zero(x)
+end
+
+@testset "isdefined" begin
+    ir = @code_ir f_isdefined(1.)
+    # The `isdefined` node must not survive with a value argument in its place.
+    @test !any(ir) do (_, stmt)
+        IRTools.isexpr(stmt.expr, :isdefined)
+    end
+    fir = func(ir)
+    @test fir(nothing, 2.) === 6.    # y defined
+    @test fir(nothing, -1.) === 0.   # y undefined -> else branch
+    @test passthrough(f_isdefined, 2.) === 6.
+    @test passthrough(f_isdefined, -1.) === 0.
+end


### PR DESCRIPTION
Fixes #143.

## Problem

`@isdefined(y)` on a conditionally-defined local lowers to `Expr(:isdefined, slot)`. The `ssa!` pass `prewalk`s that node and substitutes the slot with its reaching *value*, producing `isdefined(<ssa-value>)`:

```julia
function f(x)
    local y
    x > 0 && (y = 3x)
    @isdefined(y) ? y : zero(x)
end
```

Before:

```
3: (%5)
  %6 = $(Expr(:isdefined, %5))   # isdefined of the block-argument VALUE
  br 5 unless %6
  ...
```

`%5` correctly carries `Undefined()` on the unassigned path, but `isdefined(%5)` asks whether the SSA value is defined (always true), so the check is lost — `f(-1.0)` returns `Undefined()` instead of `zero(x)`. The same malformed node also **segfaults Julia 1.12's codegen** under Zygote (FluxML/Zygote.jl#1662, downstream JuliaGraphs/GraphNeuralNetworks.jl#623).

## Fix

Handle `Expr(:isdefined, slot)` specially in the `ssa!` rename walk. Since a possibly-undefined slot becomes a block argument carrying the `Undefined()` sentinel, the definedness of its reaching value `r` is `!(r isa Undefined)` (statically `false` for the entry `undef` sentinel, `true` for a constant):

```
3: (%5)
  %6 = %5 isa IRTools.Inner.Undefined
  %7 = !%6
  br 5 unless %7
  ...
```

Now `f(2.0) == 6.0` and `f(-1.0) == 0.0`.

## Tests

New `isdefined` testset in `test/compiler.jl` checks that no `isdefined` node survives with a value argument, and that both the defined and undefined paths evaluate correctly through `func(ir)` and the `passthrough` dynamo. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)