### PR TITLE
Also translate `isdefined` of an argument variable

### DIFF
--- a/src/passes/passes.jl
+++ b/src/passes/passes.jl
@@ -302,6 +302,11 @@ function ssa!(ir::IR)
         # `isdefined` must not be renamed like an ordinary use: substituting the
         # slot with its reaching value discards the definedness information.
         definedness(reaching(b, x.args[1]))
+      elseif isexpr(x, :isdefined) && length(x.args) == 1 && x.args[1] isa Variable
+        # An argument slot is already lowered to a variable by the time we get here
+        # (see `IR(::Meta)`), so `isdefined` of it arrives pre-substituted; recover
+        # the definedness test the same way.
+        definedness(x.args[1])
       else
         x
       end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -410,6 +410,10 @@ function f_isdefined(x)
     @isdefined(y) ? y : zero(x)
 end
 
+# `isdefined` of an argument: the arg slot is lowered to a variable before `ssa!`,
+# so this arrives as `isdefined(<variable>)` rather than `isdefined(<slot>)`.
+f_isdefined_arg(x) = @isdefined(x) ? x * 2 : zero(x)
+
 @testset "isdefined" begin
     ir = @code_ir f_isdefined(1.)
     # The `isdefined` node must not survive with a value argument in its place.
@@ -421,4 +425,12 @@ end
     @test fir(nothing, -1.) === 0.   # y undefined -> else branch
     @test passthrough(f_isdefined, 2.) === 6.
     @test passthrough(f_isdefined, -1.) === 0.
+
+    ir = @code_ir f_isdefined_arg(1.)
+    @test !any(ir) do (_, stmt)
+        IRTools.isexpr(stmt.expr, :isdefined)
+    end
+    fir = func(ir)
+    @test fir(nothing, 2.) === 4.
+    @test passthrough(f_isdefined_arg, 2.) === 4.
 end


### PR DESCRIPTION
Follow-up to #144.

That PR translated `Expr(:isdefined, slot)`, but missed one form: an **argument** slot is lowered to a variable *before* `ssa!` runs (in `IR(::Meta)`, via the `_rename` pass in `wrap.jl`). So `isdefined` of an argument arrives at `ssa!` already substituted, as `isdefined(<variable>)` rather than `isdefined(<slot>)`, and was left untranslated.

Minimal trigger:

```julia
f(x) = @isdefined(x) ? x * 2 : zero(x)   # lowers to isdefined(_2), _2 == x
```

The leftover `isdefined(<value>)` node still segfaults Julia 1.12's codegen under Zygote — e.g. `gradient(x -> (@info "m" foo=x; x^2), 2f0)`, where the differentiated variable is passed as a logging keyword argument (FluxML/Zygote.jl#1662).

Since IRTools represents every undefined value (locals, arguments, catch vars) with the same `Undefined()` sentinel, the already-resolved variable form is handled exactly like the slot form: `!(v isa Undefined)`.

Extends the `isdefined` testset with `f_isdefined_arg`. Full suite passes.

> Note: 0.4.18 isn't registered yet, so this can fold into that release rather than needing a separate 0.4.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)